### PR TITLE
Adapt to 2.0 (WIP)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,17 +90,17 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-rest-client</artifactId>
-			<version>1.21.1</version>
+			<version>1.21.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.21.1</version>
+			<version>1.21.4</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.21.1</version>
+			<version>1.21.4</version>
 		</dependency>
 		<dependency>
             <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
Updated the RestAPITest to run against 2.0, is still work in progress.
Run into an issue where a user has no permission on an entity and the old error messages keep saying that the user has no COUNT permission on an entity. The new error message is that the user has no READ permission on EntityType. Unsure if this change in behavior is intended or a bug.